### PR TITLE
feat: astro-font - optimize fonts & prevent CLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/check": "^0.4.1",
     "astro": "^4.1.2",
+    "astro-font": "^0.0.77",
     "typescript": "^5.3.3"
   }
 }

--- a/src/css/base/structure.css
+++ b/src/css/base/structure.css
@@ -4,7 +4,7 @@ body {
 
 body,
 button {
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'var(--font-mont)', sans-serif;
   color: #222;
 }
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@ import Header from '../components/Header.astro'
 import Footer from '../components/Footer.astro'
 
 import { getLangFromUrl, useTranslations } from '../i18n/utils'
+import { AstroFont } from 'astro-font'
 
 const currentLang = getLangFromUrl(Astro.url)
 const t = useTranslations(currentLang)
@@ -54,9 +55,19 @@ const t = useTranslations(currentLang)
 		<meta property="twitter:image" content="/img/icons/meta.png" />
 
 		<!-- Font -->
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap" rel="stylesheet">
+		<AstroFont
+			config={[
+				{
+					src: [],
+					preload: false,
+					display: "swap",
+					name: "Montserrat",
+					fallback: "sans-serif",
+					cssVariable: "font-mont",
+					googleFontsURL: 'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700',
+				},
+			]}
+		/>
 
 		<meta name="generator" content={Astro.generator} />
 	</head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,6 +790,11 @@ array-iterate@^2.0.0:
   resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-2.0.1.tgz#6efd43f8295b3fee06251d3d62ead4bd9805dd24"
   integrity sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==
 
+astro-font@^0.0.77:
+  version "0.0.77"
+  resolved "https://registry.yarnpkg.com/astro-font/-/astro-font-0.0.77.tgz#70145a6a1458e431510eb5ceb625a6996889e11c"
+  integrity sha512-dh5TX2uxwqdFq15DF9cbRZgEdE9o8q522MP6xZYs+rnd3dexfDsIJMeEIDNVO7rkRxwJ7sphhCqTmdWvUJaiDg==
+
 astro@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/astro/-/astro-4.1.2.tgz#d26523fc181806d8aa1733b4dbe3de15cb2b0ede"


### PR DESCRIPTION
Astro Font: https://www.launchfa.st/blog/building-astro-font

# Changes

This PR integrates `astro-font` which automatically generates the fallback font and pass it as the CSS Variable.